### PR TITLE
Fix headers for kernels >= 4.20

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
-(11.12.2009)
+(07.17.2019)
+1.6.0 -- fix kernels >= 5
 
 1.5.0 -- Minor Bugfixes: 
 -- Fixed compilation errors on older kernels and RHEL

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ fmem$(VERSION)-objs := lkm.o
 all:	clean fmem$(VERSION)
 
 fmem$(VERSION) : clean
-	make -C $(KERNEL_SRC_DIR) SUBDIRS=`pwd` modules
+	make -C $(KERNEL_SRC_DIR) KBUILD_EXTMOD=`pwd` modules
 
 install:
 	./run.sh

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-fmem 1.5.0
+fmem 1.6.0
 
 This repo is just a github mirror of the original fmem module.
 

--- a/lkm.c
+++ b/lkm.c
@@ -29,11 +29,16 @@
 #include <linux/ptrace.h>
 #include <linux/device.h>
 #include <linux/highmem.h>
-#include <linux/bootmem.h>
 #include <linux/pfn.h>
 #include <linux/version.h>
 
 #include "debug.h"
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,20,0)
+# include <linux/bootmem.h>
+#else
+# include <linux/memblock.h>
+#endif
 
 #ifdef CONFIG_IA64
 # include <linux/efi.h>


### PR DESCRIPTION
Since 4.20 `bootmem.h` no longer exists. Definitions were moved to `memblock.h` so this should work. Tested on 4.20.0 (Arch Linux).

See: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=57c8a661d95dff48dd9c2f2496139082bbaf241a