### PR TITLE
5.6.4 fix

### DIFF
--- a/lkm.c
+++ b/lkm.c
@@ -96,7 +96,7 @@ void *my_xlate_dev_mem_ptr(unsigned long phys)
 	}
 
 	// Not RAM, so it is some device (can be bios for example)
-	addr = (void __force *)ioremap_nocache(start, PAGE_SIZE);
+	addr = (void __force *)ioremap_cache(start, PAGE_SIZE);
 	if (addr)
 		addr = (void *)((unsigned long)addr | (phys & ~PAGE_MASK));
 	return addr;


### PR DESCRIPTION
Manjaro 5.6.4-1-rt3 complains about implicit declaration of ioremap_nocache and suggests ioremap_cache - which indeed after change lets the compilation succeed. 