### PR TITLE
Implement support for kernels 5.7.0 and newer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+.*.cmd
+Module.symvers
+fmem.ko
+fmem.mod
+fmem.mod.c
+modules.order

--- a/run.sh
+++ b/run.sh
@@ -2,12 +2,12 @@
 
 a1="0x"`cat /proc/kallsyms | grep ' page_is_ram' | head -1 |cut -d ' ' -f 1`
 
-
 if [ "$a1" == "0x" ]; then
 	echo "Cannot find symbol 'page_is_ram'";
 	exit;
 fi
 
+rmmod fmem
 echo -n "Module: insmod fmem.ko a1=$a1 : ";
 insmod fmem.ko a1="$a1" || exit;
 echo "OK";


### PR DESCRIPTION
Linux kernels 5.7.0 and newer unexport kallsyms_lookup_name() and
kallsyms_on_each_symbol(). So use kprobes system to access it.

The idea is taken from LTTng module, see https://lkml.org/lkml/2020/5/5/478
https://github.com/lttng/lttng-modules/blob/master/src/wrapper/kallsyms.c

Drop support for 2.6.26 and older kernels to simplify code.

Methods of getting address of page_is_ram() we're using now:

1. Use kprobes to find the kallsyms_lookup_name() location for 5.7.0+ kernels.
2. Use kallsyms_on_each_symbol() for kernels 2.6.30 and newer.
3. Get value by yourself, and give it to module as parameter.