### PR TITLE
If merged, this commit will remove a non-existent include

### DIFF
--- a/lkm.c
+++ b/lkm.c
@@ -24,7 +24,6 @@
 #include <linux/moduleparam.h>
 #include <linux/mm.h>
 #include <linux/vmalloc.h>
-#include <linux/raw.h>
 #include <linux/tty.h>
 #include <linux/ptrace.h>
 #include <linux/device.h>


### PR DESCRIPTION
The file /include/linux/raw.h no longer exists in the current kernel version and will fail to compile.